### PR TITLE
add ability to upload several files with the same name

### DIFF
--- a/mediabin-backend/models/mediabin.js
+++ b/mediabin-backend/models/mediabin.js
@@ -2,7 +2,8 @@ const mongoose = require('mongoose')
 
 const mediaSchema = new mongoose.Schema({
   content: mongoose.Schema.Types.Mixed,
-  type: String
+  type: String,
+  name: String
 })
 
 mediaSchema.set('toJSON', {

--- a/mediabin-frontend/package-lock.json
+++ b/mediabin-frontend/package-lock.json
@@ -18,6 +18,7 @@
         "react-dom": "^18.1.0",
         "react-s3": "^1.3.1",
         "react-scripts": "5.0.1",
+        "react-uuid": "^2.0.0",
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
@@ -12778,6 +12779,11 @@
         "node": ">=10"
       }
     },
+    "node_modules/react-uuid": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/react-uuid/-/react-uuid-2.0.0.tgz",
+      "integrity": "sha512-FNUH/8WR/FEtx0Bu6gmt1eONfc413hhvrEXFWUSFGvznUhI4dYoVZA09p7JHoTpnM4WC2D/bG2YSxGKXF4oVLg=="
+    },
     "node_modules/readable-stream": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
@@ -24711,6 +24717,11 @@
           "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q=="
         }
       }
+    },
+    "react-uuid": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/react-uuid/-/react-uuid-2.0.0.tgz",
+      "integrity": "sha512-FNUH/8WR/FEtx0Bu6gmt1eONfc413hhvrEXFWUSFGvznUhI4dYoVZA09p7JHoTpnM4WC2D/bG2YSxGKXF4oVLg=="
     },
     "readable-stream": {
       "version": "3.6.0",

--- a/mediabin-frontend/package.json
+++ b/mediabin-frontend/package.json
@@ -13,6 +13,7 @@
     "react-dom": "^18.1.0",
     "react-s3": "^1.3.1",
     "react-scripts": "5.0.1",
+    "react-uuid": "^2.0.0",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/mediabin-frontend/src/App.js
+++ b/mediabin-frontend/src/App.js
@@ -1,5 +1,7 @@
 import { useEffect, useState } from "react"
 import { uploadFile } from 'react-s3';
+import uuid from 'react-uuid';
+
 import mediaService from "./services/media"
 
 window.Buffer = window.Buffer || require("buffer").Buffer;
@@ -53,14 +55,24 @@ const App = () => {
 
   const handleFileUpload = async (event) => {
     event.preventDefault()
+    console.log(file)
+
+    // Creates a copy of the file with a random name in order
+    // not to overwrite existing files in AWS with the same name.
+    const fileToUpload = new File([file], uuid())
+    console.log(fileToUpload)
 
     try {
-      const uploadedFile = await uploadFile(file, config)
+      const uploadedFile = await uploadFile(fileToUpload, config)
+      console.log(uploadedFile)
 
       const newMedia = await mediaService.createMedia({
         content: uploadedFile.location,
-        type: fileType
+        type: fileType,
+        name: file.name
       })
+
+      console.log(newMedia)
 
       setAllMedia(allMedia.concat(newMedia))
     } catch (e) {
@@ -110,7 +122,7 @@ const App = () => {
           return (
             <p>
               <a href={media.content}>
-                <button>Download file</button>
+                <button>Download {media.name}</button>
               </a>
             </p>
           )


### PR DESCRIPTION
Previously when uploading a file with a name already in AWS S3, the file was overwritten or instead fetched from the cache and thus being the wrong file. Now all files are uploaded to AWS S3 with a random name which fixes this issue.