### PR TITLE
fix text upload size

### DIFF
--- a/mediabin-backend/controllers/media.js
+++ b/mediabin-backend/controllers/media.js
@@ -12,7 +12,7 @@ mediaRouter.post('/', async (request, response) => {
   if (request.body.type === 'text') {
     media = new Media({
       ...request.body,
-      size: request.headers['content-length']
+      size: request.body.content.length
     })
   } else {
     media = new Media({


### PR DESCRIPTION
Fix text upload size by estimating the byte size of the text instead of using the request body size. As one char can be approximated to one byte, simply setting the text length as the size fixes the bug.

closes #63 